### PR TITLE
Add filterUnits attribute to whitelist

### DIFF
--- a/svg-scanner.php
+++ b/svg-scanner.php
@@ -54,6 +54,7 @@ class AllowedAttributesCustom extends enshrined\svgSanitize\data\AllowedAttribut
 				'enable-background',
 				'fill',
 				'fillRule',
+				'filterUnits',
 				'from',
 				'horiz-adv-x',
 				'panose-1', // Deprecated but still in use, remove in 2023.


### PR DESCRIPTION
This patch adds the `filterUnits` attribute to the whitelist.